### PR TITLE
Check if yarn php and composer are available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ then
   echo "${setterDb}" >> ".env.local"
   composer install || err "Is composer alive?"
   yarn install || err "Error with Yarn"
-  php bin/console doctrine:database:create || err "Error withDoctrine database create"
+  php bin/console doctrine:database:create || err "Error with Doctrine database create"
   php bin/console doctrine:migrations:migrate --no-interaction || err "Error with Doctrine database migrate"
   yarn encore prod || err "Error with Yarn"
   echo '*************************************'

--- a/install.sh
+++ b/install.sh
@@ -12,11 +12,25 @@ err () {
     >&2 printf "ERROR : %s\n" "${mess}"
     exit "$code"
 }
+
+required_commands ()
+{
+    # Check if an executable exist
+    # $programs : executables separated with spaces
+    local programs
+    programs="${*}"
+    for p in $programs
+    do
+        command -v "$p" >/dev/null 2>&1 || err "${p} not found, Cashbox installer needs \`${programs}\`." 128
+    done
+}
+
 printf "Cashbox will be installed in %s\n" "$SCRIPTPATH"
 printf 'this program suppose you work with mysql installed @127.0.0.1:3306. Say YES to continue : '
 read -r yes
 if [ "$yes" = 'YES' ]
 then
+  required_commands "yarn composer php"
   cd "$SCRIPTPATH" || err "Can't cd into ${SCRIPTPATH}"
   printf "Your SQL login : "
   read -r username


### PR DESCRIPTION
This is a little improvement that check required command before do anything.
It could be useful to create a log file for `yarn`, `php` and `composer` output (or all the install script) then if someone have problems, she|he could sent this logfile.

Like my previous PR, I can't check install process, for my next, I'll install a VM with all needed packages (^_^).